### PR TITLE
prevent crash when infusion recipe instability is too high

### DIFF
--- a/src/main/java/net/glease/tc4tweak/asm/TC4Transformer.java
+++ b/src/main/java/net/glease/tc4tweak/asm/TC4Transformer.java
@@ -59,6 +59,7 @@ public class TC4Transformer implements IClassTransformer {
             })
             .put("thaumcraft.common.lib.world.dim.CellLoc", new TransformerFactory(CellLocVisitor::new))
             .put("thaumcraft.common.lib.world.dim.MazeHandler", new TransformerFactory(MazeHandlerVisitor::new))
+            .put("thaumcraft.common.tiles.TileInfusionMatrix", new TransformerFactory(TileInfusionMatrixVisitor::new))
             .build();
 
     static void catching(Exception e) {

--- a/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
+++ b/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
@@ -1,0 +1,40 @@
+package net.glease.tc4tweak.asm;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class TileInfusionMatrixVisitor extends ClassVisitor {
+
+    public TileInfusionMatrixVisitor(int api, ClassVisitor cv) {
+        super(api, cv);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        final MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        if (name.equals("craftCycle") && desc.equals("()V")) {
+            TC4Transformer.log.debug("Injecting Math#abs before Random#nextInt calls in CraftCycle()");
+            return new LoadMathAbsVisitor(api, mv);
+        } else {
+            return mv;
+        }
+    }
+
+    private static class LoadMathAbsVisitor extends MethodVisitor {
+
+        public LoadMathAbsVisitor(int api, MethodVisitor mv) {
+            super(api, mv);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            if(opcode == Opcodes.INVOKEVIRTUAL && owner.equals("java/util/Random") && name.equals("nextInt") && desc.equals("(I)I") && !itf) {
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "abs", "(I)I", false);
+            }
+            super.visitMethodInsn(opcode, owner, name, desc, itf);
+        }
+
+    }
+
+}

--- a/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
+++ b/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
@@ -30,12 +30,10 @@ public class TileInfusionMatrixVisitor extends ClassVisitor {
         @Override
         public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
             if(opcode == Opcodes.INVOKEVIRTUAL && owner.equals("java/util/Random") && name.equals("nextInt") && desc.equals("(I)I") && !itf) {
-                mv.visitLdcInsn(1);
+                mv.visitInsn(Opcodes.ICONST_1);
                 mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "max", "(II)I", false);
             }
             super.visitMethodInsn(opcode, owner, name, desc, itf);
         }
-
     }
-
 }

--- a/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
+++ b/src/main/java/net/glease/tc4tweak/asm/TileInfusionMatrixVisitor.java
@@ -14,7 +14,7 @@ public class TileInfusionMatrixVisitor extends ClassVisitor {
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
         final MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
         if (name.equals("craftCycle") && desc.equals("()V")) {
-            TC4Transformer.log.debug("Injecting Math#abs before Random#nextInt calls in CraftCycle()");
+            TC4Transformer.log.debug("Injecting Math#max before Random#nextInt calls in CraftCycle()");
             return new LoadMathAbsVisitor(api, mv);
         } else {
             return mv;
@@ -30,7 +30,8 @@ public class TileInfusionMatrixVisitor extends ClassVisitor {
         @Override
         public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
             if(opcode == Opcodes.INVOKEVIRTUAL && owner.equals("java/util/Random") && name.equals("nextInt") && desc.equals("(I)I") && !itf) {
-                mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "abs", "(I)I", false);
+                mv.visitLdcInsn(1);
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "max", "(II)I", false);
             }
             super.visitMethodInsn(opcode, owner, name, desc, itf);
         }


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11290

it injects some Math.max calls before calling random#nextInt to prevent a crash.

Now what that does is that recipes that have an instability > 33 will be as instable as a recipe having 33 instability. So if anyone wants to have more instability effects they'd have to unlock this part that resets it to 25 max 
![image](https://user-images.githubusercontent.com/57050655/191855597-720dcd3e-755d-42b7-be77-8b03276c0675.png)
